### PR TITLE
Add "Back" button to UpdatingView and add "Launch game on close" checkbox

### DIFF
--- a/application/GW2 Addon Manager/Backend/Configuration/UserConfig.cs
+++ b/application/GW2 Addon Manager/Backend/Configuration/UserConfig.cs
@@ -11,7 +11,9 @@ namespace GW2_Addon_Manager
         public string loader_version;
         public string bin_folder;
         public bool isupdate;
+        public bool launch_game;
         public string game_path;
+        public string exe_name;
         public string current_addon_list; // hash of the master branch
         public Dictionary<string, bool> default_configuration;
         public Dictionary<string, string> version;

--- a/application/GW2 Addon Manager/Backend/Configuration/configuration.cs
+++ b/application/GW2 Addon Manager/Backend/Configuration/configuration.cs
@@ -35,8 +35,7 @@ namespace GW2_Addon_Manager
         /// <returns></returns>
         public static UserConfig getConfigAsYAML()
         {
-            String updateFile = null;
-
+            string updateFile;
             if (fileSys.File.Exists(config_file_path))
                 updateFile = fileSys.File.ReadAllText(config_file_path);
             else
@@ -187,10 +186,12 @@ namespace GW2_Addon_Manager
                 if (fileSys.Directory.Exists(config.game_path.ToString() + "\\bin64"))
                 {
                     config.bin_folder = "bin64";
+                    config.exe_name = "Gw2-64.exe";
                 }
                 else if (fileSys.Directory.Exists(config.game_path.ToString() + "\\bin"))
                 {
                     config.bin_folder = "bin";
+                    config.exe_name = "Gw2.exe";
                 }
                 setConfigAsYAML(config);
             }

--- a/application/GW2 Addon Manager/Backend/Updating/UpdateHelpers.cs
+++ b/application/GW2 Addon Manager/Backend/Updating/UpdateHelpers.cs
@@ -49,6 +49,7 @@ namespace GW2_Addon_Manager
             viewModel.ProgBarLabel = "Updates Complete";
             viewModel.DownloadProgress = 100;
             viewModel.CloseBtnEnabled = true;
+            viewModel.BackBtnEnabled = true;
         }
     }
 }

--- a/application/GW2 Addon Manager/Resources/config_template.yaml
+++ b/application/GW2 Addon Manager/Resources/config_template.yaml
@@ -2,7 +2,9 @@ application_version: v1.1.1
 loader_version:
 bin_folder:
 isupdate: true
+launch_game: false
 game_path: C:\Program Files\Guild Wars 2
+exe_name:
 default_configuration:
   d3d9_wrapper: false
 version:

--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml.cs
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml.cs
@@ -81,7 +81,16 @@ namespace GW2_Addon_Manager
 
         /***** UPDATE button *****/
         private void update_button_clicked(object sender, RoutedEventArgs e)
-        {        
+        {
+            //If bin folder doesn't exist then LoaderSetup intialization will fail.
+            var userConfig = Configuration.getConfigAsYAML();
+            if (userConfig.bin_folder == null)
+            {
+                MessageBox.Show("Unable to locate Guild Wars 2 /bin/ or /bin64/ folder." + Environment.NewLine + "Please verify Game Path is correct.",
+                                "Unable to Update", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             List<AddonInfoFromYaml> selectedAddons = new List<AddonInfoFromYaml>();
 
             AddonInfoFromYaml wrapper = AddonYamlReader.getAddonInInfo("d3d9_wrapper");

--- a/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml
+++ b/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml
@@ -58,24 +58,63 @@
             </StackPanel>
         </Border>
 
-        <Label Grid.Row ="3" Margin="45,0,0,0" Name="currentTask" Content="{Binding ProgBarLabel}" VerticalAlignment="Top" FontFamily="Leelawadee UI" FontSize="14" Foreground="White" Grid.ColumnSpan="2"/>
-        <ProgressBar Value="{Binding DownloadProgress}" Grid.Row ="3" Margin="50,10,0,0" Width="750" Height="10" Name="overall_progressBar" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="#E53DBDC3" Grid.ColumnSpan="2"/>
-        <Button Grid.Row ="3"
-                x:Name="closeProgram"
-                Height="45"
-                Width="120"
-                Content="FINISH"
-                HorizontalAlignment="Right"
-                Margin="0,10,175,0"
-                Foreground="White"
-                Background="#CC6795AA"
-                FontFamily="Footlight MT Light"
-                FontSize="16"
-                BorderThickness="1"
-                BorderBrush="#FF6E6E6E"
-                Click="close_clicked"
-                IsEnabled="{Binding CloseBtnEnabled}"
-                Style="{StaticResource BigContentButton}"
-                />
+        <Label Grid.Row ="3" Margin="45,0,0,0" Name="currentTask" Content="{Binding ProgBarLabel}" VerticalAlignment="Top" FontFamily="Leelawadee UI" FontSize="14" Foreground="White"/>
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <ProgressBar Value="{Binding DownloadProgress}" Grid.RowSpan="2" Grid.Column="0" Margin="50,10,10,10" Height="10" Name="overall_progressBar" VerticalAlignment="Center" Foreground="#E53DBDC3"/>
+            <Button Grid.Column="1"
+                    x:Name="back"
+                    Height="45"
+                    Width="120"
+                    Content="BACK"
+                    Margin="5"
+                    Foreground="White"
+                    Background="DimGray"
+                    FontFamily="Footlight MT Light"
+                    FontSize="16"
+                    BorderThickness="1"
+                    BorderBrush="#FF6E6E6E"
+                    Click="back_clicked"
+                    IsEnabled="{Binding BackBtnEnabled}"
+                    Style="{StaticResource BigContentButton}"
+                    />
+            <Button Grid.Column="2"
+                    x:Name="closeProgram"
+                    Height="45"
+                    Width="120"
+                    Content="CLOSE"
+                    Margin="5, 5, 100, 5"
+                    Foreground="White"
+                    Background="#CC6795AA"
+                    FontFamily="Footlight MT Light"
+                    FontSize="16"
+                    BorderThickness="1"
+                    BorderBrush="#FF6E6E6E"
+                    Click="close_clicked"
+                    IsEnabled="{Binding CloseBtnEnabled}"
+                    Style="{StaticResource BigContentButton}"
+                    />
+            <CheckBox x:Name="launchOnClose"
+                      Content="Launch game when closing"
+                      Foreground="White"
+                      Grid.Row="2"
+                      Grid.Column="1"
+                      Grid.ColumnSpan="2"
+                      FontFamily="Footlight MT Light"
+                      FontSize="16"
+                      VerticalAlignment="Center"
+                      VerticalContentAlignment="Center"
+                      Margin="5">
+            </CheckBox>
+        </Grid>
+        
     </Grid>
 </Page>

--- a/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml.cs
+++ b/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
+using System.Web;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -24,6 +26,8 @@ namespace GW2_Addon_Manager
 
             LoaderSetup settingUp = new LoaderSetup();
             Task.Run(() => UpdateHelpers.UpdateAll());
+
+            launchOnClose.IsChecked = Configuration.getConfigAsYAML().launch_game;
         }
 
         /***************************** Titlebar Window Drag *****************************/
@@ -38,6 +42,30 @@ namespace GW2_Addon_Manager
         private void close_clicked(object sender, RoutedEventArgs e)
         {
             SelfUpdate.startUpdater();
+
+            if ((bool)launchOnClose.IsChecked)
+            {
+                string exeLocation = Path.Combine(Configuration.getConfigAsYAML().game_path, Configuration.getConfigAsYAML().exe_name);
+                try
+                {
+                    Process.Start(exeLocation, "-autologin");
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    MessageBox.Show($"Unable to launch game as {Configuration.getConfigAsYAML().exe_name} is missing.",
+                                     "Unable to Launch Game",
+                                     MessageBoxButton.OK,
+                                     MessageBoxImage.Error);
+                }
+            }
+
+            UserConfig config = Configuration.getConfigAsYAML();
+            if (config.launch_game != (bool)launchOnClose.IsChecked)
+            {
+                config.launch_game = (bool)launchOnClose.IsChecked;
+                Configuration.setConfigAsYAML(config);
+            }
+
             System.Windows.Application.Current.Shutdown();
         }
 
@@ -53,6 +81,12 @@ namespace GW2_Addon_Manager
             Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
             e.Handled = true;
         }
+
+        private void back_clicked(object sender, RoutedEventArgs e)
+        {
+            this.NavigationService.Navigate(new Uri("UI/OpeningPage/OpeningView.xaml", UriKind.Relative));
+        }
+
     }
 }
 

--- a/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingViewModel.cs
+++ b/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace GW2_Addon_Manager
 {
@@ -9,6 +10,7 @@ namespace GW2_Addon_Manager
     {
         /* private fields for ui bindings */
         private bool _closeBtnEnabled;
+        private bool _backBtnEnabled;
         private string _msg;
         private int _progress;
 
@@ -20,6 +22,14 @@ namespace GW2_Addon_Manager
         {
             get { return _closeBtnEnabled; }
             set { _closeBtnEnabled = value; propertyChanged($"{nameof(CloseBtnEnabled)}"); }
+        }
+        /// <summary>
+        /// Binding for whether the "BACK" button is enabled.
+        /// </summary>
+        public bool BackBtnEnabled
+        {
+            get { return _backBtnEnabled; }
+            set { _backBtnEnabled = value; propertyChanged($"{nameof(BackBtnEnabled)}"); }
         }
         /// <summary>
         /// Binding for the label above the progress bar.
@@ -37,7 +47,6 @@ namespace GW2_Addon_Manager
             get { return _progress; }
             set { _progress = value; propertyChanged($"{nameof(DownloadProgress)}"); }
         }
-
 
         /********** Class Structure/Other Methods **********/
 
@@ -65,6 +74,9 @@ namespace GW2_Addon_Manager
             onlyInstance = this;
             ProgBarLabel = "Updating Add-Ons";
             CloseBtnEnabled = false;
+            BackBtnEnabled = false;
+
+
         }
         /// <summary>
         /// Accessor for the one instance of this class; if the instance has not been initialized, does that before returning it.


### PR DESCRIPTION
Completes functionality specified in #36 and fixes a crash:

- Adds `Back` button to `UpdatingView`. Enabled when updates complete.

- Adds "Launch game on close" checkbox, saved to config as `launch_game` (default `false`). Also adds `exe_name` to specify which exe (`Gw2.exe` or `Gw2-64.exe`) to launch. Set in `Configuration.DetermineSystemType()`.

- Also adds null `UserConfig.bin_folder` check to `update_button_clicked`. If bin_folder was null (e.g. incorrect `game_path`) application would crash during `LoaderSetup()`.