### PR TITLE
Change disable/enable operations to use FileSystem.MoveDirectory() instead of Directory.Move() 

### DIFF
--- a/application/GW2 Addon Manager/Backend/Updating/GenericUpdater.cs
+++ b/application/GW2 Addon Manager/Backend/Updating/GenericUpdater.cs
@@ -219,7 +219,7 @@ namespace GW2_Addon_Manager
                 {
                     if (addon_info.install_mode != "arc")
                     {
-                        Directory.Move(
+                        FileSystem.MoveDirectory(
                             Path.Combine(Path.Combine(info.game_path, "addons"), addon_info.folder_name),
                             Path.Combine("Disabled Plugins", addon_info.folder_name)
                             );
@@ -273,10 +273,10 @@ namespace GW2_Addon_Manager
                     if (addon_info.install_mode != "arc")
                     {
                         //non-arc
-                        Directory.Move(
-                        Path.Combine("Disabled Plugins", addon_info.folder_name),
-                        Path.Combine(Path.Combine(info.game_path, "addons"), addon_info.folder_name)
-                        );
+                        FileSystem.MoveDirectory(
+                            Path.Combine("Disabled Plugins", addon_info.folder_name),
+                            Path.Combine(Path.Combine(info.game_path, "addons"), addon_info.folder_name)
+                            );
                     }
                     else
                     {


### PR DESCRIPTION
`Directory.Move()` does not like moving across volume boundaries, so having your game installed on a different drive (e.g. `E:\`) than the addon manager (e.g. `C:\`) causes the application to crash.

Exact exception for context:
```
System.IO.IOException: 'Source and destination path must have identical roots. Move will not work across volumes.'
```

This commit changes the two offending instances of this that I ran into, though there are probably more elsewhere that should be changed.

----

Another option that might be worth considering instead is to store the disabled add-ons in the same directory as the enabled ones, just in a disabled directory. This avoids the ambiguity of using a disabled add-ons path that is relative to the current working directory. I have an example of this in this commit [here](https://github.com/richteer/GW2-Addon-Manager/commit/142b4e12ca861bee641f7cca115a2ab361c107da).