### PR TITLE
Added folder selection dialog for easier game directory selection.

### DIFF
--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml
@@ -146,7 +146,8 @@
             Command="{Binding Path=DownloadSelfUpdate}"
             ToolTip="This will download the application update and then restart the program."
             />
-        <Button Command="{Binding Path=SetGamePath}"
+        <Button Name="SelectDirectoryBtn"
+                Click="SelectDirectoryBtn_OnClick"
                 Grid.Row="2"
                 Margin="725,0,0,9"
                 HorizontalAlignment="Left"
@@ -158,8 +159,6 @@
                 FontSize="14"
                 FontFamily="Candara"
                 Height="25"
-                
-                BorderThickness="1"
                 BorderBrush="LightGray"
                 Style="{StaticResource BigContentButton}"
             />

--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml.cs
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningView.xaml.cs
@@ -5,7 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using System.Windows.Input;
+using Application = System.Windows.Application;
+using MessageBox = System.Windows.MessageBox;
 
 namespace GW2_Addon_Manager
 {
@@ -120,5 +123,19 @@ namespace GW2_Addon_Manager
             e.Handled = true;
         }
 
+        private void SelectDirectoryBtn_OnClick(object sender, RoutedEventArgs e)
+        {
+            using (var pathSelectionDialog = new FolderBrowserDialog
+            {
+                ShowNewFolderButton = false, 
+                SelectedPath = OpeningViewModel.GetInstance.GamePath, 
+                RootFolder = Environment.SpecialFolder.Desktop
+            })
+            {
+                var result = pathSelectionDialog.ShowDialog();
+                if(result == DialogResult.OK)
+                    OpeningViewModel.GetInstance.GamePath = pathSelectionDialog.SelectedPath;
+            }
+        }
     }
 }

--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
@@ -103,14 +103,6 @@ namespace GW2_Addon_Manager
         /***************************/
         /***** Button Handlers *****/
         /***************************/
-        /// <summary>
-        /// Handles button commands for the "set" button next to the game path text field in the opening screen.
-        /// <see cref="Configuration.SetGamePath(string)"/>
-        /// </summary>
-        public ICommand SetGamePath
-        {
-            get => new RelayCommand<object>(param => Configuration.SetGamePath(GamePath), true);
-        }
 
         /* [Configuration Options] drop-down menu */
         
@@ -176,10 +168,22 @@ namespace GW2_Addon_Manager
             get => updateProgress;
             set => SetProperty(ref updateProgress, value);
         }
+
         /// <summary>
         /// Content of the text box that contains the game path the program is set to look for the game in.
         /// </summary>
-        public string GamePath { get; set; }
+        public string GamePath
+        {
+            get => _gamePath;
+            set
+            {
+                if (value == _gamePath) return;
+                SetProperty(ref _gamePath, value);
+                Configuration.SetGamePath(GamePath);
+            }
+        }
+        private string _gamePath;
+
         /// <summary>
         /// A string that is assigned a value if there is an update available.
         /// </summary>


### PR DESCRIPTION
When i first ran app i thought it was a bug, that "Select directory" button does nothing. I think it is more intuitive for user that it will open windows folder selection dialog and set Game path this way. 
Also added two-way binding to "Game path" text box, so user can still manualy type in path and it will work just fine (although it wont be saved in config until focus from the text box is lost i.e. on checkbox click). 
Thought and suggestion are welcome. 

Also may fix #56.